### PR TITLE
Add pyproject.toml and fix NaN crashes on unlined games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 .local
 .claude
 training/runs/
+*.egg-info/

--- a/nfelo/Model/Nfelo.py
+++ b/nfelo/Model/Nfelo.py
@@ -1,3 +1,4 @@
+import math
 import pandas as pd
 import numpy
 import statistics
@@ -210,18 +211,30 @@ class Nfelo:
         row['nfelo_home_probability_open'] = elo_to_prob(row['nfelo_dif_open'])
         self._set_translator(row['nfelo_home_probability_open'], 'win_prob', row['season'])
         row['nfelo_home_line_open'] = -self._translator.spread.posted
-        row['home_cover_prob_open'] = self._translator.cover_prob(-row['home_line_open'])
-        row['home_push_prob_open'] = self._translator.push_prob(-row['home_line_open'])
-        row['home_loss_prob_open'] = 1 - row['home_cover_prob_open'] - row['home_push_prob_open']
-        row['home_open_ev'] = (row['home_cover_prob_open'] - 1.1 * row['home_loss_prob_open']) / 1.1
-        row['away_open_ev'] = (row['home_loss_prob_open'] - 1.1 * row['home_cover_prob_open']) / 1.1
+        if not math.isnan(row['home_line_open']):
+            row['home_cover_prob_open'] = self._translator.cover_prob(-row['home_line_open'])
+            row['home_push_prob_open'] = self._translator.push_prob(-row['home_line_open'])
+            row['home_loss_prob_open'] = 1 - row['home_cover_prob_open'] - row['home_push_prob_open']
+            row['home_open_ev'] = (row['home_cover_prob_open'] - 1.1 * row['home_loss_prob_open']) / 1.1
+            row['away_open_ev'] = (row['home_loss_prob_open'] - 1.1 * row['home_cover_prob_open']) / 1.1
+        else:
+            row['home_cover_prob_open'] = float('nan')
+            row['home_push_prob_open'] = float('nan')
+            row['home_loss_prob_open'] = float('nan')
+            row['home_open_ev'] = float('nan')
+            row['away_open_ev'] = float('nan')
         ## Close ##
         row['nfelo_home_probability_close'] = elo_to_prob(row['nfelo_dif_close'])
         self._set_translator(row['nfelo_home_probability_close'], 'win_prob', row['season'])
         row['nfelo_home_line_close'] = -self._translator.spread.posted
-        row['home_cover_prob_close'] = self._translator.cover_prob(-row['home_line_close'])
-        row['home_push_prob_close'] = self._translator.push_prob(-row['home_line_close'])
-        row['home_loss_prob_close'] = 1 - row['home_cover_prob_close'] - row['home_push_prob_close']
+        if not math.isnan(row['home_line_close']):
+            row['home_cover_prob_close'] = self._translator.cover_prob(-row['home_line_close'])
+            row['home_push_prob_close'] = self._translator.push_prob(-row['home_line_close'])
+            row['home_loss_prob_close'] = 1 - row['home_cover_prob_close'] - row['home_push_prob_close']
+        else:
+            row['home_cover_prob_close'] = float('nan')
+            row['home_push_prob_close'] = float('nan')
+            row['home_loss_prob_close'] = float('nan')
         ## add aways for down stream pipes ##
         row['away_loss_prob_close'] = row['home_cover_prob_close']
         row['away_push_prob_close'] = row['home_push_prob_close']

--- a/nfelo/Utilities/clv.py
+++ b/nfelo/Utilities/clv.py
@@ -1,3 +1,4 @@
+import math
 from nfelotranslation import Translator
 
 def calc_clv(
@@ -23,6 +24,8 @@ def calc_clv(
     '''
     ## negate spreads at the nfelo<->nfelotranslation boundary; nfelo uses ##
     ## sportsbook (negative=home favored), nfelotranslation uses positive=home ##
+    if math.isnan(original_home_spread) or math.isnan(current_home_spread):
+        return float('nan'), float('nan')
     nt_open = -original_home_spread
     nt_close = -current_home_spread
     translator = Translator(nt_open, 'spread', season=int(season), side='home')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nfelo"
+dynamic = ["version"]
+requires-python = ">=3.8"
+dependencies = [
+    "beautifulsoup4",
+    "numpy",
+    "pandas",
+    "requests",
+    "statsmodels",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "nfelo.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["nfelo*"]


### PR DESCRIPTION
## Summary

- Adds `pyproject.toml` so the package can be installed via `pip install -e .`; version is sourced dynamically from `nfelo.__version__` to avoid duplication with `nfelo/__init__.py`
- Guards against `ValueError` in `Nfelo.project_game()` when `home_line_open` or `home_line_close` is NaN — upcoming games without posted lines now produce NaN for market-dependent fields instead of crashing
- Same NaN guard added to `calc_clv()` — returns `(nan, nan)` early when either spread is missing
- Adds `*.egg-info/` to `.gitignore`

## Test plan

- [ ] `pip install -e .` completes cleanly and `python -c "import nfelo"` works
- [ ] `from nfelo import update_nfelo; update_nfelo()` runs end-to-end without error when Week 1 games have no posted lines
- [ ] Output CSVs (projections, elo snapshot) are written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)